### PR TITLE
Update 2 dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.19</version>
+            <version>8.36.2</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,6 @@
     <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
     <geotab.sdk.version>1.0-SNAPSHOT</geotab.sdk.version>
     <slf4j.version>1.7.30</slf4j.version>
-    <log4j.version>1.2.17</log4j.version>
     <log4j.jcl.version>2.13.3</log4j.jcl.version>
     <lombok.version>1.18.12</lombok.version>
     <guava.version>29.0-jre</guava.version>
@@ -81,9 +80,9 @@
     </dependency>
 
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>${log4j.version}</version>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-1.2-api</artifactId>
+        <version>2.13.3</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
     <geotab.sdk.version>1.0-SNAPSHOT</geotab.sdk.version>
     <slf4j.version>1.7.30</slf4j.version>
+    <log4j.version>2.13.3</log4j.version>
     <log4j.jcl.version>2.13.3</log4j.jcl.version>
     <lombok.version>1.18.12</lombok.version>
     <guava.version>29.0-jre</guava.version>
@@ -82,7 +83,7 @@
     <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-1.2-api</artifactId>
-        <version>2.13.3</version>
+        <version>${log4j.version}</version>
     </dependency>
 
     <dependency>

--- a/quality-enforcement/checkstyle/google_checks.xml
+++ b/quality-enforcement/checkstyle/google_checks.xml
@@ -40,6 +40,12 @@
 
   <module name="SuppressWarningsFilter"/>
 
+    <module name="LineLength">
+      <property name="max" value="100"/>
+      <property name="ignorePattern"
+        value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+    </module>
+
   <module name="TreeWalker">
     <module name="SuppressWarningsHolder"/>
     <module name="OuterTypeFilename"/>
@@ -54,11 +60,6 @@
       <property name="allowEscapesForControlCharacters" value="true"/>
       <property name="allowByTailComment" value="true"/>
       <property name="allowNonPrintableEscapes" value="true"/>
-    </module>
-    <module name="LineLength">
-      <property name="max" value="100"/>
-      <property name="ignorePattern"
-        value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
     </module>
     <module name="AvoidStarImport"/>
     <module name="OneTopLevelClass"/>


### PR DESCRIPTION
Dependabot reported that that `log4j` and `CheckStyle` dependencies are outdated. These 2 Maven dependencies are updated in this PR.

Jira Ticket: MYG-16563 (https://jira.geotab.com/browse/MYG-16563)

**NOTE: This pull request (https://github.com/Geotab/sdk-java-samples/pull/1) can be closed since my PR already addresses updating the CheckStyle dependency.**